### PR TITLE
InvSave에서 event.drops.shuffle()을 먼저하지 않고 drops를 선언한 상태에서 하는것이 좋다고 보아서 수정합니다.

### DIFF
--- a/src/main/kotlin/io/github/minibox/miniplugin/InvSave.kt
+++ b/src/main/kotlin/io/github/minibox/miniplugin/InvSave.kt
@@ -11,18 +11,14 @@ import java.util.*
 class InvSave : Listener {
     @EventHandler
     fun dropHead(event: PlayerDeathEvent) {
-        event.drops.shuffle()
         val drops = event.drops as MutableList
-
+        drops.shuffle()
         val iterator = drops.iterator()
         while (iterator.hasNext()) {
             val item: ItemStack = iterator.next()
-
             if (Random().nextBoolean()) continue
-
             iterator.remove()
             event.itemsToKeep.add(item)
-
         }
     }
 }


### PR DESCRIPTION
event.drops에 대한 중복 드롭 할당을 제거하고 가독성을 높이기 위해 shuffle() 메서드 호출을 다음 줄로 옮겼습니다.